### PR TITLE
Add voice system identifiers of LGE in the appendix

### DIFF
--- a/DAB.md
+++ b/DAB.md
@@ -1920,7 +1920,7 @@ versions | a list of versions of the protocol implemented on the device
 | Google Assistant   |   GoogleAssistant       |
 | Amazon Alexa       |   AmazonAlexa           |
 | LG ThinQ           |   LGThinQ               |
-| Yandex Alice       |   yandexAlice           |
+| Yandex Alice       |   YandexAlice           |
 
 ### Process for Contributing to Registry
 

--- a/DAB.md
+++ b/DAB.md
@@ -1919,6 +1919,8 @@ versions | a list of versions of the protocol implemented on the device
 | :---------------:  |  :-------:              |
 | Google Assistant   |   GoogleAssistant       |
 | Amazon Alexa       |   AmazonAlexa           |
+| LG ThinQ           |   LGThinQ               |
+| Yandex Alice       |   yandexAlice           |
 
 ### Process for Contributing to Registry
 


### PR DESCRIPTION
Add voice system identifiers used in LG webOS TV.
LG ThinQ - This is ThinQ developed by LGE.
Yandex Alice - This is Alice developed by Yandex and only supports Russia.