### PR TITLE
Added BBC iPlayer to app registry

### DIFF
--- a/DAB.md
+++ b/DAB.md
@@ -1912,11 +1912,12 @@ versions | a list of versions of the protocol implemented on the device
 # 7. Appendix
 
 ## Application ID Registry
-| Application        |  DAB appId  |
-| :---------------:  |  :-------:  |
-| Netflix            |   Netflix   |
-| YouTube            |   YouTube   |
-| Amazon Prime Video |  PrimeVideo |
+| Application        | DAB appId         |
+| :----------------: | :---------------: |
+| Netflix            | Netflix           |
+| YouTube            | YouTube           |
+| Amazon Prime Video | PrimeVideo        |
+| BBC iPlayer        | uk.co.bbc.iplayer |
 
 ## Voice System Name Registry
 


### PR DESCRIPTION
Added an entry for BBC iPlayer, and made associated formatting changes, to the app registry table. 

The identifier, uk.co.bbc.iplayer, matches an identifier we use in our own application specification. 