### PR TITLE
Define SystemSettings interface

### DIFF
--- a/DAB.md
+++ b/DAB.md
@@ -882,7 +882,7 @@ type GetCurrentSystemSettingsRequest = DabRequest
 
 #### Response Format
 ```typescript
-interface GetCurrentSystemSettingsResponse extends DabResponse {
+interface SystemSettings {
    language: rfc_5646_language_tag;
    outputResolution: OutputResolution;
    memc: boolean;
@@ -897,6 +897,9 @@ interface GetCurrentSystemSettingsResponse extends DabResponse {
    audioVolume: int;
    mute: boolean;
    textToSpeech: boolean;
+}
+
+interface GetCurrentSystemSettingsResponse extends DabResponse, SystemSettings {
 }
 ```
 


### PR DESCRIPTION
This interface is used in definitions of request and response formats for /system/settings/set, but was never actually defined anywhere.