### PR TITLE
Clarify environment considerations for list system settings operation

### DIFF
--- a/DAB.md
+++ b/DAB.md
@@ -687,7 +687,9 @@ Error:
 ### Operation: List system settings
 *Operation model: Request / Response*
 
-This operation is used to retrieve the possible values that can be assigned to each system setting.
+This operation is used to retrieve the possible values that can be assigned to each system setting. 
+
+Implementations must consider the current operating environment and surface only the setting values that the device believes is possible to set.
 
 #### Request Topic
 


### PR DESCRIPTION
For example: 

If an STB is connected to an HD Display, when someone lists the OutputResolution system setting, it must not list 4K as an available option.

We want implementations to return just like they would in the system settings menu that a consumer would interact with.

This will prevent system setting _set_ calls to impossible values.