### PR TITLE
Add Disney+ to the Application Registry

### DIFF
--- a/DAB.md
+++ b/DAB.md
@@ -1922,13 +1922,14 @@ versions | a list of versions of the protocol implemented on the device
 # 7. Appendix
 
 ## Application ID Registry
-| Application        | DAB appId         |
-| :----------------: | :---------------: |
-| Netflix            | Netflix           |
-| YouTube            | YouTube           |
-| Amazon Prime Video | PrimeVideo        |
-| BBC iPlayer        | uk.co.bbc.iplayer |
-| YouTube TV         | YouTubeTV         |
+| Application        | DAB appId             |
+| :----------------: | :-------------------: |
+| Netflix            | Netflix               |
+| YouTube            | YouTube               |
+| Amazon Prime Video | PrimeVideo            |
+| BBC iPlayer        | uk.co.bbc.iplayer     |
+| YouTube TV         | YouTubeTV             |
+| Disney+            | com.disney.disneyplus |
 
 ## Voice System Name Registry
 


### PR DESCRIPTION
Added the Disney+ identifier to the application registry. Eventually we would probably add additional products such as ESPN and Hulu, but starting with Disney+.